### PR TITLE
docs(cn): permissions

### DIFF
--- a/getting_started/permissions.md
+++ b/getting_started/permissions.md
@@ -1,50 +1,31 @@
-## Permissions {#permissions}
+## 权限 {#permissions}
 
-Deno is secure by default. Therefore, unless you specifically enable it, a deno
-module has no file, network, or environment access for example. Access to
-security-sensitive areas or functions requires the use of permissions to be
-granted to a deno process on the command line.
+默认情况下，Deno 是安全的。因此，除非你特意开启，Deno 模块是没有文件、网络以及环境的访问权限的。在命令行参数中为 deno 进程授权后才能访问安全敏感的功能。
 
-For the following example, `mod.ts` has been granted read-only access to the
-file system. It cannot write to it, or perform any other security-sensitive
-functions.
+在以下示例中，`mod.ts`只被授予文件系统的只读权限。它无法对其进行写入，或执行任何其他对安全性敏感的操作。
 
 ```shell
 deno run --allow-read mod.ts
 ```
 
-### Permissions list {#permissions-list}
+### 权限列表 {#permissions-list}
 
-The following permissions are available:
+可用权限如下：
 
-- **-A, --allow-all** Allow all permissions. This disables all security.
-- **--allow-env** Allow environment access for things like getting and setting
-  of environment variables.
-- **--allow-hrtime** Allow high-resolution time measurement. High-resolution
-  time can be used in timing attacks and fingerprinting.
-- **--allow-net=\<allow-net\>** Allow network access. You can specify an
-  optional, comma-separated list of domains to provide an allow-list of allowed
-  domains.
-- **--allow-plugin** Allow loading plugins. Please note that --allow-plugin is
-  an unstable feature.
-- **--allow-read=\<allow-read\>** Allow file system read access. You can specify
-  an optional, comma-separated list of directories or files to provide a
-  allow-list of allowed file system access.
-- **--allow-run** Allow running subprocesses. Be aware that subprocesses are not
-  run in a sandbox and therefore do not have the same security restrictions as
-  the deno process. Therefore, use with caution.
-- **--allow-write=\<allow-write\>** Allow file system write access. You can
-  specify an optional, comma-separated list of directories or files to provide a
-  allow-list of allowed file system access.
+- **-A, --allow-all** 允许所有权限，这将禁用所有安全限制。
+- **--allow-env** 允许访问环境，例如读取和设置环境变量。
+- **--allow-hrtime** 允许高精度时间测量，高精度时间能够在计时攻击和特征识别中使用。
+- **--allow-net=\<allow-net\>** 允许网络访问。你可以指定一个可选的以逗号分隔的域名列表，来作为域名白名单。
+- **--allow-plugin** 允许加载插件。请注意：--allow-plugin 是一个不稳定功能。
+- **--allow-read=\<allow-read\>** 允许读取文件系统。你可以指定一个可选的以逗号分隔的目录或文件列表，来作为文件系统白名单。
+- **--allow-run** 允许运行子进程。请注意，子进程不在沙箱中运行，所以没有与 deno 进程相同的安全限制。因此，请谨慎使用。
+- **--allow-write=\<allow-write\>** 开启文件系统写入权限。你可以指定一个可选的以逗号分隔的目录或文件列表，来作为文件系统白名单。
 
-### Permissions allow-list {#permissions-allow-list}
+### 权限白名单 {#permissions-allow-list}
 
-Deno also allows you to control the granularity of some permissions with
-allow-lists.
+Deno 还允许你控制白名单权限的粒度。
 
-This example restricts file system access by allow-listing only the `/usr`
-directory, however the execution fails as the process was attempting to access a
-file in the `/etc` directory:
+这个例子通过只包含 `/usr` 的白名单来限制文件系统访问权限，但是由于进程试图访问 `/etc` 目录中的文件，所以执行失败。
 
 ```shell
 $ deno run --allow-read=/usr https://deno.land/std@$STD_VERSION/examples/cat.ts /etc/passwd
@@ -54,15 +35,15 @@ error: Uncaught PermissionDenied: read access to "/etc/passwd", run again with t
     ...
 ```
 
-Try it out again with the correct permissions by allow-listing `/etc` instead:
+通过设定 `/etc` 为白名单来赋予正确的权限后再次尝试：
 
 ```shell
 deno run --allow-read=/etc https://deno.land/std@$STD_VERSION/examples/cat.ts /etc/passwd
 ```
 
-`--allow-write` works the same as `--allow-read`.
+`--allow-write` 与 `--allow-read` 工作原理一样
 
-### Network access: {#network-access}
+### 网络访问 {#network-access}
 
 _fetch.ts_:
 
@@ -70,23 +51,22 @@ _fetch.ts_:
 const result = await fetch("https://deno.land/");
 ```
 
-This is an example of how to allow-list hosts/urls:
+这是一个设置 host 或 url 白名单的示例：
 
 ```shell
 deno run --allow-net=github.com,deno.land fetch.ts
 ```
 
-If `fetch.ts` tries to establish network connections to any other domain, the
-process will fail.
+如果 `fetch.ts` 尝试与其他域名建立网络连接，那么这个进程将会失败。
 
-Allow net calls to any host/url:
+允许访问任意 host/url：
 
 ```shell
 deno run --allow-net fetch.ts
 ```
 
-### Conference {#conference}
+### 会议 {#conference}
 
-Ryan Dahl. (September 25, 2020).
-[The Deno security model](https://www.youtube.com/watch?v=r5F6dekUmdE#t=34m57).
+Ryan Dahl. (9月 25, 2020).
+[Deno安全模型](https://www.youtube.com/watch?v=r5F6dekUmdE#t=34m57).
 Speakeasy JS.


### PR DESCRIPTION
permissions 翻译完成。英文原版文档换行太多了，无法保证翻译前后行数一致。